### PR TITLE
Making interferopy a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The package was developed to aid in the studies of the interstellar medium in hi
 
 ## Usage
 
-Two classes, *Cube* and *MultiCube*, are defined in [cube.py](cube.py) with the goal to speed up the analysis of 2D or 3D data cubes, which are produced by imaging the interferometric data. A collection of helper functions are also available in [tools.py](tools.py). Enable their functionality by importing them.
+Two classes, *Cube* and *MultiCube*, are defined in [cube.py](src/cube.py) with the goal to speed up the analysis of 2D or 3D data cubes, which are produced by imaging the interferometric data. A collection of helper functions are also available in [tools.py](src/tools.py). Enable their functionality by importing them.
     
     from interferopy.cube import Cube, MultiCube
     import interferopy.tools as iftools
@@ -99,7 +99,7 @@ These methods perform both the residual scaling correction, and the primary beam
 
 ### Tools
 
-Additional helper functions are defined in [tools.py](tools.py), for example
+Additional helper functions are defined in [tools.py](src/tools.py), for example
 
     iftools.sigfig(1.234, digits=3)  # rounds to 3 significant digits yielding 1.23
     iftools.calcrms(cub.im)  # calculate noise rms of the input array
@@ -118,7 +118,7 @@ A method to stack different positions in a single 2D map: *stack2d()*, and other
 
 ### Miscellaneous
 
-Several specialized tasks and helper functions for data reduction in CASA are located in [casatools.py](casatools.py) and [casatools_vla_pipe.py](casatools_vla_pipe.py).
+Several specialized tasks and helper functions for data reduction in CASA are located in [casatools.py](src/casatools.py) and [casatools_vla_pipe.py](src/casatools_vla_pipe.py).
 
 ## Examples
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+'''
+interferopy
+
+Setup script
+'''
+
+from distutils.core import setup 
+setup(name='interferopy',
+	  version= '0.1',
+	  author = 'Mladen Novak',
+	  author_email = 'novak@mpia.de',
+	  package_dir = {'interferopy':'src'},
+      package_data = {'interferopy': ['examples/*']},
+	  packages = ['interferopy']
+	  )

--- a/src/casatools.py
+++ b/src/casatools.py
@@ -1,0 +1,9 @@
+
+
+# Write a CASA mask region file using a list of coordinates (degrees) and circle sizes (radius in arcses)
+def casareg(outfile, ra, dec, rad):
+	f = open(outfile, "w")
+	f.write("#CRTFv0\n")
+	for i in range(len(ra)):
+		f.write("circle[[" + str(ra[i]) + "deg," + str(dec[i]) + "deg], " + str(rad[i]) + "arcsec]" + '\n')
+	f.close()

--- a/src/casatools_vla_pipe.py
+++ b/src/casatools_vla_pipe.py
@@ -1,0 +1,181 @@
+"""VLA pipeline helper functions"""
+__author__ = "Mladen Novak"
+
+import numpy as np
+import os
+import scipy.constants
+
+# import some stuff from CASA
+if os.getenv('CASAPATH') is not None:
+	# import casadef
+	from taskinit import *
+	msmd = msmdtool() # need for metadata
+
+
+def flagtemplate_add(sdm="", flagcmds=[], outfile=""):
+	"""
+	Append additional flagging commands to the flagtemplate if they are not present already.
+	Useful for L-band VLA HI obs: e.g. flagcmds=["mode='manual' spw='1,2:0~64,4'"]
+	:param sdm: path to visibility data, will append .flagtemplate.txt to it
+	:param flagcmds: list of commands to append into the template file
+	:param outfile: override naming to custom filename
+	:return: None
+	"""
+	if outfile == "":
+		outfile = sdm + ".flagtemplate.txt"
+
+	if os.path.exists(outfile):
+		with open(outfile, "r") as f:
+			content = f.read().splitlines()
+	else:
+		content = [""]
+
+	with open(outfile, "a") as f:
+		for cmd in flagcmds:
+			if cmd not in content:
+				f.write("\n" + cmd + "\n")
+	return
+
+
+def partition_cont_range(line_freqs=[], line_widths=[], spw_start=1, spw_end=2):
+	"""
+	Cuts one continuum range into smaller ones to avoid lines.
+	:param line_freqs: line frequencies in GHz
+	:param line_widths: widths of lines in GHz to cut from the continuum
+	:param spw_start: start of the SPW in GHz
+	:param spw_end: end of the SPW in GHz
+	:return: list of continuum chunks, each defined as a dictionary with start and end freqs in GHz.
+	"""
+
+	# make sure lists are treaded as float vectors
+	line_freqs = np.array(line_freqs)
+	line_widths = np.array(line_widths)
+
+	# define line ranges that will be excluded
+	line_starts = line_freqs - 0.5 * line_widths
+	line_ends = line_freqs + 0.5 * line_widths
+
+	# start with the whole spw as one continuum chunk
+	cont_chunks = [dict(start=spw_start, end=spw_end)]
+
+	for i in range(len(line_freqs)):
+		# for each line loop over the continuum chunk collection and modify it in the process
+		j = 0
+		while j < len(cont_chunks):
+			# line outside chunk, skip
+			if line_ends[i] < cont_chunks[j]["start"] or line_starts[i] > cont_chunks[j]["end"]:
+				pass
+
+			# line covers whole chunk, delete it
+			elif line_starts[i] <= cont_chunks[j]["start"] and line_ends[i] >= cont_chunks[j]["end"]:
+				cont_chunks.pop(j)
+				j = j - 1
+
+			# line covers left edge only, edit cont chunk start
+			elif line_starts[i] < cont_chunks[j]["start"] and line_ends[i] >= cont_chunks[j]["start"]:
+				cont_chunks[j]["start"] = line_ends[i]
+
+			# line covers right edge only, edit cont chunk end
+			elif line_starts[i] <= cont_chunks[j]["end"] and line_ends[i] > cont_chunks[j]["end"]:
+				cont_chunks[j]["end"] = line_starts[i]
+
+			# line in the middle, splits chunk into two
+			elif line_starts[i] > cont_chunks[j]["start"] and line_ends[i] < cont_chunks[j]["end"]:
+				cont_chunks.insert(j + 1, dict(start=line_ends[i], end=cont_chunks[j]["end"]))
+				cont_chunks[j]["end"] = line_starts[i]
+				j = j + 1
+
+			# other non-implemented scenarios (are all useful cases covered? any pathological edge case?)
+			else:
+				pass
+
+			# progress to the next chunk
+			j = j + 1
+
+	return cont_chunks
+
+
+def build_cont_dat(vis="", line_freqs=[], line_widths=[], fields=[], outfile="cont.dat", overwrite=False, append=False):
+	"""
+	Creates a cont.dat file for the VLA pipeline. Must be run in CASA (uses msmetadata).
+	It currently reads SPW edges in the original observed frame (usually TOPO),
+	but writes them down as LSRK. Should not matter much, edges should be flagged anyway.
+	Example of cont.dat content from NRAO online documentation:
+	https://science.nrao.edu/facilities/vla/data-processing/pipeline/#section-25
+	:param vis: path to the measurement set
+	:param line_freqs: line frequencies (obs frame, LSRK) in GHz
+	:param line_widths: widths of lines (obs frame, LSRK) in GHz to cut from the continuum
+	:param fields: science target fields. If empty, TARGET intent fields are used.
+	:param outfile: path to the output cont.dat file
+	:param overwrite: if True and the outfile exists, it will be overriten
+	:param append: add at the end of existing cont.dat file, useful for optimising lines per field
+	:return: None
+	"""
+
+	# if no fields are provided use observe_target intent
+	# I saw once a calibrator also has this intent so check carefully
+	msmd.open(vis)
+	if len(fields) < 1:
+		# fields = msmd.fieldsforintent("*OBSERVE_TARGET*", True)
+		fields = msmd.fieldsforintent("*TARGET*", True)
+
+	if len(fields) < 1:
+		print("ERROR: no fields!")
+		return
+
+	if os.path.exists(outfile) and not overwrite and not append:
+		print("ERROR: file already exists!")
+		return
+
+	# generate a dictonary containing continuum chunks for every spw of every field
+	cont_dat = {}
+	for field in fields:
+		spws = msmd.spwsforfield(field)
+		cont_dat_field = {}
+
+		for spw in spws:
+			# Get freq range of the SPW
+			chan_freqs = msmd.chanfreqs(spw)
+			# SPW edges are reported in whichever frame was used for observing (usually TOPO)
+			# TODO: implement some transformations to LSRK for the edges?
+			spw_start = np.min(chan_freqs) * 1e-9  # GHz
+			spw_end = np.max(chan_freqs) * 1e-9  # GHz
+			cont_chunks = partition_cont_range(line_freqs, line_widths, spw_start, spw_end)
+			cont_dat_field.update({spw: cont_chunks})
+		# print(spw, cont_chunks)
+		# print(spw_start, spw_end)
+
+		cont_dat.update({field: cont_dat_field})
+
+	msmd.close()
+
+	# write the dictionary into a file usable by the CASA VLA pipeline
+	access_mode = "a" if append else "w"
+	with open(outfile, access_mode) as f:
+		for field in cont_dat.keys():
+			f.write("\nField: " + field + "\n")
+			for spw in cont_dat[field].keys():
+				if len(cont_dat[field][spw]) > 0:
+					f.write("\nSpectralWindow: " + str(spw) + "\n")
+					for chunk in cont_dat[field][spw]:
+						f.write(str(chunk["start"]) + "~" + str(chunk["end"]) + "GHz LSRK\n")
+			f.write("\n")
+
+	print("DONE: written in " + outfile)
+	return
+
+
+def lines_rest2obs(line_freqs_rest, line_widths_kms, vrad0):
+	"""
+	Get observed frame frequencies and widths of the lines.
+	:param line_freqs_rest: list of rest-frame line frequencies
+	:param line_widths_kms: list of rest-frame linewidths in km/s
+	:param vrad0: systemic velocity of the galaxy in km/s
+	:return: line_freqs, line_widths, both in GHz
+	"""
+	ckms = scipy.constants.c / 1000.
+	line_freqs = np.array(line_freqs_rest) * (1 - vrad0 / ckms)
+	line_widths = np.array(line_freqs) * line_widths_kms / ckms
+
+	return line_freqs, line_widths
+

--- a/src/cube.py
+++ b/src/cube.py
@@ -1,0 +1,1053 @@
+import os
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+from astropy import wcs
+import scipy.constants as const
+
+import interferopy.tools as tools
+
+
+class Cube:
+	"""
+	Cube object represents interferometric data such as a map (2D) or a cube (3D).
+	Allows performing tasks such as aperture integration or spectrum extraction.
+	It is instantiated by reading in a fits file.
+
+	Example:
+		filename="cube.image.fits"
+		ra, dec, freq = (205.533741, 9.477317341, 222.54) # coord for the emission line
+		c=Cube(filename)
+		# spectrum from the circular aperture, with associated error
+		flux, err, _ = c.spectrum(ra=ra, dec=dec, radius=1.5, calc_error=True)
+		# curve of growth up to the maximum radius, in steps of one pixel, in a chosen frequency channel
+		radius, flux, err, _ = c.growing_aperture(ra=ra, dec=dec, freq=freq, maxradius=5, calc_error=True)
+	"""
+
+	def __init__(self, filename: str):
+		"""
+		:param filename: Path string to the fits image.
+		"""
+		if os.path.exists(filename):
+			self.filename = filename
+			self.hdu = None
+			"""Hdu of the loaded fits file."""
+
+			self.head = None
+			"""Image header of the loaded fits file."""
+
+			self.im: np.ndarray = None
+			"""Data cube indexed as im[ra, dec, freq]. This is transposed version of what the fits package returns"""
+
+			self.wcs: wcs.WCS = None
+			"""Datacube world coordinate system."""
+
+			self.beam = None
+			"""Table of beams per channel, keywords: bmaj, bmin, bpa."""
+
+			self.beamvol: np.ndarray = None
+			"""Beam volume in pixels (number of pixels in a beam)."""
+
+			self.pixsize: float = None
+			"""Size of the pixel in arcsec."""
+
+			self.nch: int = None
+			"""Number of channels in a cube."""
+
+			self.freqs: np.ndarray = None
+			"""Array of frequencies corresponding to cube channels."""
+
+			self.reffreq: float = None
+			"""Reference frequency in GHz (from image header)."""
+
+			self.deltafreq: float = None
+			"""Channel width in GHz."""
+
+			self.__rms: np.ndarray = None
+			"""Array of rms values per channel. Computed on demand."""
+			self.__load_fitsfile()
+		else:
+			raise FileNotFoundError(filename)
+
+	def __load_fitsfile(self):
+		"""
+		Read the fits file and extract common useful data into Cube class attributes.
+		"""
+		self.log("Open " + self.filename)
+		self.hdu = fits.open(self.filename)
+		self.head = self.hdu[0].header
+		self.pixsize = self.head["cdelt2"] * 3600  # arcsec, assumes square pixels
+
+		# quick fix for a faulty header card that contained \n char - remove the tag altogether
+		if "ORIGIN" in self.head.keys():
+			self.head.remove('ORIGIN')
+
+		# transpose the cube data so that intuitive im[ra,dec,freq,stokes] indexing can be used
+		# number of cube dimensions
+		naxis = len(self.hdu[0].data.shape)
+		if naxis == 4 and self.hdu[0].data.shape[0] == 1:
+			# drop the fourth (Stokes) axis if only a single plane is present
+			image = self.hdu[0].data.T[:, :, :, 0]
+			naxis = 3
+		elif naxis == 4:
+			image = self.hdu[0].data.T
+			self.log("Warning: did test 4D full polarization cubes with multiple Stokes axes.")
+		elif naxis == 3:
+			image = self.hdu[0].data.T
+		elif naxis == 2:
+			# add the third axis, if missing, because several methods require it
+			image = self.hdu[0].data[np.newaxis, :, :].T
+			naxis = 3
+			self.log("Warning: did not test 2D maps with the missing 3rd axis.")
+		else:
+			raise RuntimeError("Invalid number of cube dimensions.")
+		self.im = image
+		self.naxis = naxis
+
+		# save the world coord system
+		self.wcs = wcs.WCS(self.head, naxis=naxis)
+
+		# populate frequency details (freq array, channel size, number of channels)
+		# convert from velocity header if necessary, scale to GHz
+		nch = 1
+		if naxis >= 3:
+			nch = self.im.shape[2]  # number of (freq) channels in the cube
+			# if frequencies are already 3rd axis
+			if str(self.head["CTYPE3"]).strip().lower() == "freq":
+				_, _, freqs = self.wcs.all_pix2world(int(self.im.shape[0] / 2), int(self.im.shape[1] / 2), range(nch), 0)
+				freqs *= 1e-9  # in GHz
+				self.deltafreq = self.head["CDELT3"] * 1e-9
+				self.reffreq = self.head["CRVAL3"] * 1e-9
+			# if frequencies are given in radio velocity, convert to freqs
+			elif str(self.head["CTYPE3"]).strip().lower() == "vrad":
+				_, _, vels = self.wcs.all_pix2world(int(self.im.shape[0] / 2), int(self.im.shape[1] / 2), range(nch), 0)
+				if "RESTFREQ" in self.head.keys():
+					reffreq = self.head["RESTFREQ"] * 1e-9
+				elif "RESTFRQ" in self.head.keys():
+					reffreq = self.head["RESTFRQ"] * 1e-9
+				else:
+					# unknown
+					reffreq = 0
+				freqs = reffreq * (1 - vels / const.c)  # in GHz
+				self.reffreq = reffreq
+
+				if "CUNIT3" in self.head.keys() and self.head["CUNIT3"].strip().lower() == "km/s":
+					vel_scale = 1000
+				else:
+					vel_scale = 1
+				self.deltafreq = reffreq * (self.head["CDELT3"] * vel_scale / const.c)
+			else:
+				freqs = None
+				self.log("Warning: unknown 3rd axis format.")
+			self.freqs = freqs
+		self.nch = nch
+
+		# populate beam data
+		# single beam from the main header
+		if "BMAJ" in self.head.keys() and "BMIN" in self.head.keys() and "BPA" in self.head.keys():
+			beam = {"bmaj": self.head["BMAJ"] * 3600, "bmin": self.head["BMIN"] * 3600, "bpa": self.head["BPA"]}
+		else:
+			beam = {"bmaj": 0, "bmin": 0, "bpa": 0}
+
+		# if there is a beam per channel table present, take it
+		if nch > 1 and len(self.hdu) > 1:
+			beam_table = self.hdu[1].data  # this is inserted by CASA, there is unit metadata, but should be arcsec
+		# otherwise clone the single beam across all channels in a new table
+		else:
+			if len(self.im.shape) >= 3:
+				nch = self.im.shape[2]
+			else:
+				nch = 1
+
+			beam_table = Table()
+			beam_table.add_columns([Table.Column(name='bmaj', data=np.ones(nch) * beam["bmaj"])])
+			beam_table.add_columns([Table.Column(name='bmin', data=np.ones(nch) * beam["bmin"])])
+			beam_table.add_columns([Table.Column(name='bpa', data=np.ones(nch) * beam["bpa"])])
+			beam_table.add_columns([Table.Column(name='chan', data=range(nch))])
+			beam_table.add_columns([Table.Column(name='pol', data=np.zeros(nch))])
+		self.beam = beam_table
+
+		# model image is Jy/pixel, and since beam volume divides integrated fluxes, set it to 1 in this case
+		if "BUNIT" in self.head.keys() and self.head["BUNIT"].strip().lower().endswith("/pixel"):
+			self.beamvol = np.array([1] * nch)
+		else:
+			# "BUNIT" in self.head.keys() and self.head["BUNIT"].strip().lower().endswith("/beam"):
+			# sometimes BUNIT is not given, although beam is in the header (e.g. the PSF map)
+			self.beamvol = np.pi / (4 * np.log(2)) * self.beam["bmaj"] * self.beam["bmin"] / self.pixsize ** 2
+			if type(self.beamvol) is Table.Column:
+				self.beamvol = self.beamvol.data
+
+	def log(self, text: str):
+		"""
+		Basic logger function to allow better functionality in the future development.
+		All class functions print info through this wrapper.
+		Could be extended to provide different levels of info, timestamps, or logging to a file.
+		"""
+		print(text)
+
+	def get_rms(self):
+		"""
+		Calculate rms for each channel of the cube. Can take some time to compute on large cubes.
+		:return: single rms value if 2D, array odf rms values for each channel if 3D cube
+		"""
+		# TODO: maybe add the option to calculate a single channel only?
+		if self.__rms is None:
+			# calc rms per channel
+			if self.nch > 1:
+				self.__rms = np.zeros(self.nch)
+				self.log("Computing rms in each channel.")
+				for i in range(self.nch):
+					self.__rms[i] = tools.calcrms(self.im[:, :, i])
+			else:
+				self.log("Computing rms.")
+				self.__rms = np.array([tools.calcrms(self.im)])
+		return self.__rms
+
+	def set_rms(self, value):
+		self.__rms = value
+
+	rms = property(get_rms, set_rms)
+	"""Rms (root mean square) per channel."""
+
+	def deltavel(self, reffreq: float = None):
+		"""
+		Compute channel width in velocity units (km/s).
+		:param reffreq: Computed around specific velocity. If empty, use referent one from the header.
+		:return: Channel width in km/s. Sign reflects how channels are ordered.
+		"""
+
+		if reffreq is None:
+			reffreq = self.reffreq
+
+		return self.deltafreq / reffreq * const.c / 1000  # in km/s
+
+	def vels(self, reffreq: float):
+		"""
+		Compute velocities of all cube channels for a given reference frequency.
+		:param reffreq: Reference frequency in GHz. If empty, use referent one from the header.
+		:return: Velocities in km/s.
+		"""
+
+		if reffreq is None:
+			reffreq = self.reffreq
+
+		return const.c / 1000 * (1 - self.freqs / reffreq)
+
+	def radec2pix(self, ra=None, dec=None, integer=True):
+		"""
+		Convert ra and dec coordinates into pixels to be used as im[px, py].
+		If no coords are given, the center of the map is assumed.
+		:param ra: Right ascention in degrees. Or list.
+		:param dec: Declination in degrees. Or list.
+		:param integer: Round the coordinate to an integer value (to be used as indices).
+		:return: Coords x and y in pixels (0 based index).
+		"""
+
+		# use the central pixel if no coords given
+		if ra is None or dec is None:
+			px = self.im.shape[0] / 2
+			py = self.im.shape[1] / 2
+		# otherwise convert radec to pixel coord
+		else:
+			if len(self.wcs.axis_type_names) < 3:
+				px, py = self.wcs.all_world2pix(ra, dec)
+			else:
+				px, py, _ = self.wcs.all_world2pix(ra, dec, self.freqs[0], 0)
+
+		# need integer indices
+		if integer:
+			px = np.asarray(np.round(px), dtype=int)
+			py = np.asarray(np.round(py), dtype=int)
+
+		return px, py
+
+	def pix2radec(self, px=None, py=None):
+		"""
+		Convert pixels coordinates into ra and dec.
+		If no coords are given, the center of the map is assumed.
+		:param px: X-axis index. Or list.
+		:param py: Y-axis index. Or list.
+		:return: Coords ra, dec in degrees
+		"""
+		if px is None or py is None:
+			px = self.im.shape[0] / 2
+			py = self.im.shape[1] / 2
+
+		if len(self.wcs.axis_type_names) < 3:
+			ra, dec = self.wcs.all_pix2world(px, py)
+		else:
+			ra, dec, _ = self.wcs.all_pix2world(px, py, self.freqs[0], 0)
+
+		return ra, dec
+
+	def freq2pix(self, freq: float = None):
+		"""
+		Get the channel number of requested frequency.
+		:param freq: Frequency in GHz.
+		:return: Channel index.
+		"""
+
+		if len(self.wcs.axis_type_names) < 3:
+			raise ValueError("No frequency axis is present.")
+			return None
+
+		if freq is None:
+			pz = self.im.shape[2] / 2
+			pz = int(round(pz))
+			return pz
+
+		if freq < np.min(self.freqs) - 0.5 * np.abs(self.deltafreq) \
+				or freq > np.max(self.freqs) + 0.5 * np.abs(self.deltafreq):
+			raise ValueError("Requested frequency is outside of the available range.")
+			return None
+
+		# This is ok, unless the 3rd axis is in velocities
+		# ra0 = self.head["CRVAL1"]
+		# dec0 = self.head["CRVAL2"]
+		# _, _, pz = self.wc.all_world2pix(ra0, dec0, freq * 1e9, 0)
+		# pz = int(np.round(pz))  # need integer index
+
+		# freqs is populated when the cube is loaded, regardless whether the header is in vels or freqs
+		# find the index with the minimum offset
+		pz = np.argmin(np.abs(self.freqs - freq))
+
+		return pz
+
+	def pix2freq(self, pz: int = None):
+		"""
+		Get the frequency of a given channel.
+		If no channel is given, the center channel is assumed.
+		:param pz: Channel index.
+		:return: Frequency in GHz.
+		"""
+
+		if len(self.wcs.axis_type_names) < 3:
+			raise ValueError("No frequency axis is present.")
+			return None
+
+		if pz is None:
+			pz = self.im.shape[2] / 2
+			pz = int(round(pz))
+
+		if pz < 0 or pz >= len(self.freqs):
+			raise ValueError("Requested channel is outside of the available range.")
+			return None
+
+		return self.freqs[pz]
+
+	def im2d(self, ch: int = 0):
+		"""
+		Get the 2D map. Convenience function to avoid indexing notation.
+		:param ch: Channel index.
+		:return: 2D numpy array.
+		"""
+		if ch < 0 or ch >= self.nch:
+			raise ValueError("Requested channel is outside of the available range.")
+			return None
+
+		return self.im[:, :, ch]
+
+	def distance_grid(self, px: float, py: float) -> np.ndarray:
+		"""
+		Grid of distances from the chosen pixel (can be subpixel accuracy).
+		Uses small angle approximation (simple Pythagorean distances).
+		Distances are measured in numbers of pixels.
+		:param px: Index of x coord.
+		:param py: Index of y coord.
+		:return: 2D grid of distances in pixels, same shape as the cube slice
+		"""
+
+		xxx = np.arange(self.im.shape[0])
+		yyy = np.arange(self.im.shape[1])
+		distances = np.sqrt((yyy[np.newaxis, :] - py) ** 2 + (xxx[:, np.newaxis] - px) ** 2)
+		return distances
+
+	def spectrum(self, ra: float = None, dec: float = None, radius=0.0,
+				 px: int = None, py: int = None, channel: int = None, freq: float = None, calc_error=False) \
+			-> (np.ndarray, np.ndarray, np.ndarray):
+		"""
+		Extract the spectrum (for 3D cube) or a single flux density value (for 2D map) at a given coord (ra, dec)
+		integrated within a circular aperture of a given radius.
+		Coordinates can be given in degrees (ra, dec) or pixels (px, py).
+		If no coordinates are given, the center of the map is assumed.
+		Single plane can be chosen instead of full spectrum by defining freq or channel.
+		If no radius is given, a single pixel value is extracted (usual units Jy/beam), otherwise aperture
+		integrated spectrum is extracted (usual units of Jy).
+		Note: use the freqs field (or velocities method) to get the x-axis values.
+		:param ra: Right ascention in degrees.
+		:param dec: Declination in degrees.
+		:param radius: Circular aperture radius in arcsec.
+		:param px: Right ascention pixel coord.
+		:param py: Declination pixel coord.
+		:param channel: Force extracton in a single channel of provided index (instead of the full cube).
+		:param freq: Frequency in GHz (alternative to channel).
+		:param calc_error: Set to False to skip error calculations, if the rms computation is slow or not necessary.
+		:return: flux, err, npix: flux (spectrum), error estimate, and number of pixels in the aperture
+		"""
+
+		if px is None or py is None:
+			px, py = self.radec2pix(ra, dec)
+		if freq is not None:
+			channel = self.freq2pix(freq)
+
+		# take single pixel value if no aperture radius given
+		if radius <= 0:
+			self.log("Extracting single pixel spectrum.")
+			flux = self.im[px, py, :]
+			if calc_error:
+				err = np.array(self.rms[:])  # single pixel error is just rms
+			else:
+				err = np.full_like(flux, np.nan)
+			npix = np.ones(len(flux))
+			# use just a single channel
+			if channel is not None:
+				flux = np.array([flux[channel]])
+				npix = np.array([npix[channel]])
+				err = np.array([err[channel]])
+		else:
+			self.log("Extracting aperture spectrum.")
+			# grid of distances from the source in arcsec, need for the aperture mask
+			distances = self.distance_grid(px, py) * self.pixsize
+
+			# select pixels within the aperture
+			w = distances <= radius
+
+			if channel is not None:
+				npix = np.array([np.sum(np.isfinite(self.im[:, :, channel][w]))])
+				flux = np.array([np.nansum(self.im[:, :, channel][w]) / self.beamvol[channel]])
+				if calc_error:
+					err = np.array(self.rms[channel] * np.sqrt(npix / self.beamvol[channel]))
+				else:
+					err = np.array([np.nan])
+			else:
+				flux = np.zeros(self.nch)
+				npix = np.zeros(self.nch)
+				for i in range(self.nch):
+					flux[i] = np.nansum(self.im[:, :, i][w]) / self.beamvol[i]
+					npix[i] = np.sum(np.isfinite(self.im[:, :, i][w]))
+				if calc_error:
+					err = np.array(self.rms * np.sqrt(npix / self.beamvol))
+				else:
+					err = np.full_like(flux, np.nan)
+
+		return flux, err, npix
+
+	def single_pixel_value(self, ra: float = None, dec: float = None, freq: float = None,
+						   channel: int = None, calc_error: bool = False):
+		"""
+		Get a single pixel value at the given coord. Optionally, return associated error.
+		Wrapper function for the "spectrum" method. If None, assumes central pixel.
+		:param ra: Right ascention in degrees.
+		:param dec: Declination in degrees.
+		:param freq: Frequency in GHz. If None, computes whole spectrum.
+		:param channel: Channel index (alternative to freq).
+		:param calc_error: If true, returns also an error estimate (rms).
+		:return: value or (value, error)
+		"""
+
+		spec, err, _ = self.spectrum(ra=ra, dec=dec, radius=0, freq=freq, channel=channel, calc_error=calc_error)
+		if calc_error:
+			return spec, err
+		else:
+			return spec
+
+	def aperture_value(self, ra: float = None, dec: float = None, freq: float = None, channel: int = None,
+					   radius: float = 1.0, calc_error=False):
+		"""
+		Get an aperture integrated value at the given coord. Optionally, return associated error.
+		Wrapper function for the "spectrum" method.
+		:param ra: Right ascention in degrees. If None, assumes central pixel.
+		:param dec: Declination in degrees.
+		:param freq: Frequency in GHz. If None, computes whole spectrum.
+		:param channel: Channel index (alternative to freq).
+		:param radius: Aperture radius in arcsec.
+		:param calc_error: If true, returns also an error estimate (rms x sqrt(num of beams in aperture)).
+		:return: value or (value, error)
+		"""
+
+		flux, err, _ = self.spectrum(ra=ra, dec=dec, radius=radius, freq=freq, channel=channel, calc_error=calc_error)
+		if calc_error:
+			return flux, err
+		else:
+			return flux
+
+	def growing_aperture(self, ra: float = None, dec: float = None, freq: float = None,
+						 maxradius=1.0, binspacing: float = None, bins: list = None,
+						 px: int = None, py: int = None, channel: int = 0,
+						 profile=False, calc_error=False) \
+			-> (np.ndarray, np.ndarray, np.ndarray, np.ndarray):
+		"""
+		Compute curve of growth at the given coordinate position in a circular aperture, growing up to the max radius.
+		Coordinates can be given in degrees (ra, dec) or pixels (px, py).
+		If no coordinates are given, the center of the map is assumed.
+		If no channel is provided, the first one is assumed.
+		:param ra: Right ascention in degrees.
+		:param dec: Declination in degrees.
+		:param freq: Frequency in GHz, takes precedence over channel param.
+		:param maxradius: Max radius for aperture integration in arcsec.
+		:param binspacing: Resolution of the growth flux curve in arcsec, default is one pixel size.
+		:param bins: Custom bins for curve growth (1D np array).
+		:param px: Right ascention pixel coord (alternative to ra).
+		:param py: Declination pixel coord (alternative to dec).
+		:param channel: Index of the cube channel to take (alternative to freq).
+		:param profile: If True, compute azimuthally averaged profile, if False, compute cumulative aperture values
+		:param calc_error: Set to False to skip error calculations, if the rms computation is slow or not necessary.
+		:return: radius, flux, err, npix - all 1D numpy arrays: aperture radius, cumulative flux within it,
+		associated Poissionain error (based on number of beams inside the aprture and the map rms), number of pixels
+		"""
+		self.log("Running growth_curve.")
+
+		# get coordinates in pixels
+		if px is None or py is None:
+			px, py = self.radec2pix(ra, dec)
+		# get grid of distances from the coordinate
+		distances = self.distance_grid(px, py) * self.pixsize
+
+		if freq is not None:
+			channel = self.freq2pix(freq)
+
+		if bins is None:
+			if binspacing is None:
+				# take one pixel size as default size
+				binspacing = self.pixsize
+			bins = np.arange(0, maxradius, binspacing)
+
+		# histogram will fail if nans are present, select only valid pixels
+		w = np.isfinite(self.im[:, :, channel])
+
+		# histogram by default sums the number of pixels
+		npix = np.array(np.histogram(distances[w], bins=bins)[0])
+		if profile:
+			pass
+		else:
+			npix = np.array(np.cumsum(npix))
+
+		# pixel values are added as histogram weights to get the sum of pixel values
+		flux = np.histogram(distances[w], bins=bins, weights=self.im[:, :, channel][w])[0]
+		if profile:
+			# mean value - azimuthally averaged
+			flux = np.array(flux / npix)
+		else:
+			# cumulative flux inside an aperture is the sum of all pixel values divided by the beam volume
+			flux = np.cumsum(flux) / self.beamvol[channel]
+
+		if calc_error:
+			if profile:
+				# error on the mean
+				nbeam = npix / self.beamvol[channel]
+				nbeam[nbeam < 1] = 1  # if there are less pixels than the beam size, better not count less than 1
+				err = np.array(self.rms[channel] / np.sqrt(nbeam))
+			else:
+				# error estimate assuming Poissonian statistics: rms x sqrt(number of independent beams inside aperture)
+				nbeam = npix / self.beamvol[channel]
+				nbeam[nbeam < 1] = 1
+				err = np.array(self.rms[channel] * np.sqrt(nbeam))
+		else:
+			err = np.full_like(flux, np.nan)
+
+		# centers of bins
+		radius = np.array(0.5 * (bins[1:] + bins[:-1]))
+
+		# old loop version, human readable, but super slow in execution for large apertures and lots of pixels
+		# for i in range(len(bins)-1):
+		# 	#w=(distances>=bins[i]) & (distances<bins[i+1]) #annulus
+		# 	w=(distances>=0) & (distances<bins[i+1]) # aperture (cumulative)
+		# 	npix[i]=np.sum(w)
+		# 	flux[i]=np.sum(im[w])/beamvol
+		# 	err[i]=rms*np.sqrt(npix[i]/beamvol) # rms times sqrt of beams used for integration
+
+		return radius, flux, err, npix
+
+	def aperture_r(self, ra: float = None, dec: float = None, freq: float = None,
+				   px: int = None, py: int = None, channel: int = 0,
+				   maxradius: float = 1.0, binspacing: float = None, bins: list = None, calc_error: bool = False):
+		"""
+		Obtain integrated flux within a circular aperture as a function of radius.
+		If freq is undefined, will return the spectrum of the 3D cube.
+		Alias function. Check the "growing_aperture" method for details.
+		Units: ra[deg], dec[deg], maxradius[arcsec], binspacing[arcsec], freq[GHz]
+		:return: (radius, flux) or (radius, flux, err) if calc_error
+		"""
+
+		radius, flux, err, npix = self.growing_aperture(ra=ra, dec=dec, freq=freq,
+														maxradius=maxradius, binspacing=binspacing, bins=bins,
+														px=px, py=py, channel=channel,
+														profile=False, calc_error=calc_error)
+		if calc_error:
+			return radius, flux, err
+		else:
+			return radius, flux
+
+	def profile_r(self, ra: float = None, dec: float = None, freq: float = None,
+				  px: int = None, py: int = None, channel: int = 0,
+				  maxradius: float = 1.0, binspacing: float = None, bins: list = None,
+				  calc_error: bool = False):
+		"""
+		Obtain azimuthaly averaged profile as a function of radius.
+		Alias function. Check the "growing_aperture" method for details.
+		Units: ra[deg], dec[deg], maxradius[arcsec], binspacing[arcsec], freq[GHz]
+		:return: (radius, profile) or (radius, profile err) if calc_error
+		"""
+		radius, profile, err, npix = self.growing_aperture(ra=ra, dec=dec, freq=freq,
+														maxradius=maxradius, binspacing=binspacing, bins=bins,
+														px=px, py=py, channel=channel,
+														profile=True, calc_error=calc_error)
+		if calc_error:
+			return radius, profile, err
+		else:
+			return radius, profile
+
+		return
+
+	def save_fitsfile(self, filename: str = None, overwrite=False):
+		"""
+		Save the cube in a fits file by storing the image and the header.
+		:param filename: Path string to the output file. Uses input filename by default
+		:param overwrite: False by default.
+		:return:
+		"""
+
+		if filename is None and self.filename is None:
+			raise ValueError("No filename was provided.")
+
+		if not overwrite and filename is None:
+			raise ValueError("Overwriting is disabled and no filename was provided.")
+
+		# use the input filename if none is provided
+		if overwrite and filename is None:
+			filename = self.filename
+
+		if os.path.exists(filename) and not overwrite:
+			raise RuntimeError("Filename exist, but overwriting is disabled.")
+
+		fits.writeto(filename, self.im.T, self.head, overwrite=overwrite)
+		self.log("Fits file saved to " + filename)
+
+
+class MultiCube:
+	"""
+	A container like object to hold multiple cubes at the same time. Cubes are stored in a dictionary.
+	Allows performing tasks such as residual scaled aperture integration or spectrum extraction.
+	Load another cube into MultiCube object by e.g. mc.load_cube("path_to_cube.residual.fits", "residual")
+
+	Example:
+		filename="cube.fits"
+		ra, dec, freq = (205.533741, 9.477317341, 222.54) # coord for the emission line
+		mc=MultiCube(filename) # will automatically try to load cube.xxx.fits, where xxx is
+								# residual, dirty, pb, model, psf, or image.pbcor
+
+		# Alternatively load each cube manually
+		# mc = MultiCube()
+		# mc.load_cube("somewhere/cube.fits", "image")
+		# mc.load_cube("elsewhere/cube.dirty.fits", "dirty")
+		# mc.load_cube("elsewhere/cube.residual.fits", "residual")
+		# mc.load_cube("elsewhere/cube.pb.fits", "pb")
+
+		# spectrum extracted from the circular aperture, with associated error, corrected for residual and PB response
+		flux, err, tab = mc.spectrum_corrected(ra=ra, dec=dec, radius=1.5, calc_error=True)
+		# tab.write("spectrum.txt", format="ascii.fixed_width", overwrite=True)  # Save results for later
+
+		# curve of growth up to the maximum radius, in steps of one pixel, in a chosen frequency channel
+		radius, flux, err, tab = mc.growing_aperture_corrected(ra=ra, dec=dec, freq=freq, maxradius=5, calc_error=True)
+		# tab.write("growth.txt", format="ascii.fixed_width", overwrite=True)  # Save results for later
+	"""
+
+	def __init__(self, filename: str = None, autoload_multi=True):
+		"""
+		Provide the file path to the final cleaned cube. Will try to find other adjacent cubes based on their names.
+		Standard key names from CASA are: image, residual, model, psf, pb, image.pbcor
+		Additional names are dirty, clean.comp
+
+		:param filename: Path string to the cleaned cube fits image.
+		:param autoload_multi: If true, attempt to find other cubes using preset (mostly CASA) suffixes.
+		"""
+
+		# these are standard suffixes from CASA tclean output (except "dirty")
+		# gildas output has different naming conventions, which are not implemnted here
+		keylist = ["image", "residual", "dirty", "pb", "model", "psf", "image.pbcor", "clean.comp"]
+		self.cubes = dict(zip(keylist, [None] * len(keylist)))
+		self.basename = None
+
+		if filename is None:
+			# just setup the basic dictionary and exit
+			return
+		elif not os.path.exists(filename):
+			raise FileNotFoundError(filename)
+
+		filenames = dict(zip(keylist, [None] * len(keylist)))
+		filenames["image"] = filename
+
+		# TODO could improve searching, but there are infinite number of ways people could name these files
+		# get the basename, which is hopefully shared between different cubes
+		extension = ".fits"
+		endings = [".image.tt0.fits", ".image.fits", ".fits"]
+		for ending in endings:
+			if filename.lower().endswith(ending):
+				self.basename = filename[:-len(ending)]
+				extension = ending.replace(".image", "")
+				break
+
+		# try to fill other filenames
+		if autoload_multi:
+			if self.basename is None:
+				raise ValueError("Unknown extension.")
+
+			# print("extension",extension)
+			for k in keylist:
+				# expected filename
+				filename_suffixed = self.basename + "." + k + extension
+				if os.path.exists(filename_suffixed):
+					filenames[k] = filename_suffixed
+
+		# load the cubes
+		for k in self.cubes.keys():
+			if filenames[k] is not None:
+				self.cubes[k] = Cube(filenames[k])
+
+		self.log("Loaded cubes: " + str(self.loaded_cubes))
+
+	def load_cube(self, filename: str, key: str = None):
+		"""
+		Add provided fits file to the MultiCube instance.
+		Known keys are: "image", "residual", "dirty", "pb", "model", "psf", "image.pbcor"
+		If the filename does not end with these words, please provide a manual key.
+		:param filename: Path string to the fits image.
+		:param key: Dictionary key name used to store the cube.
+		:return:
+		"""
+		# try to estimate the key from the filename
+		if key is None:
+			# assuming the file ends in something like .residual.fits
+			suffix = str(filename).split(".")[-2]
+			# if this suffix matches preset ones
+			if suffix in self.cubes.keys():
+				key = suffix
+
+		# Load and store new cube
+		cub = Cube(filename)
+
+		if key is None:
+			raise ValueError("Please provide key under which to store the cube.")
+
+		if len(self.loaded_cubes) > 0:
+			if cub.im.shape != self[self.loaded_cubes[0]].im.shape:
+				self.log("Warning: Loaded cube has a different shape than existing one!")
+
+		self[key] = cub
+
+	def __getitem__(self, key: str):
+		return self.cubes[key]
+
+	def __setitem__(self, key: str, value: Cube):
+		self.cubes[key] = value
+
+	def get_loaded_cubes(self):
+		"""
+		Get a list of loaded cubes (those that are not None).
+		:return: List of key names.
+		"""
+		return [k for k in self.cubes.keys() if self.cubes[k] is not None]
+
+	loaded_cubes = property(get_loaded_cubes)
+	"""List of keys corresponding to loaded cubes."""
+
+	def get_freqs(self):
+		if len(self.loaded_cubes) > 0:
+			return self[self.loaded_cubes[0]].freqs  # maybe pick explicitely self["image"].freqs
+		else:
+			raise ValueError("No cubes present!")
+
+	freqs = property(get_freqs)
+	"""Array of frequencies corresponding to cube channels (from the first loaded cube)."""
+
+	def log(self, text: str):
+		"""
+		Basic logger function to allow better functionality in the future development.
+		All class functions print info through this wrapper.
+		Could be extended to provide different levels of info, timestamps, or logging to a file.
+		"""
+		print(text)
+
+	def make_clean_comp(self, overwrite=False):
+		"""
+		Generate a clean component cube. Defined as the cleaned cube minus the residual, or, alternatively,
+		model image convolved with the clean beam. This cube is not outputted by CASA.
+		:param overwrite: If true, overrides any present "clean.comp" cube.
+		:return: None
+		"""
+		self.log("Generate clean component cube.")
+
+		if self["image"] is None:
+			raise ValueError("Cleaned cube is missing.")
+		if self["residual"] is None:
+			raise ValueError("Residual cube is missing.")
+		if self["clean.comp"] is not None and not overwrite:
+			self.log("Warning: clean.comp cube already exists and overwriting is disabled.")
+
+		cub = Cube(self["image"].filename)
+		cub.im = self["image"].im - self["residual"].im
+		cub.filename = None  # This cube is no longer the one on disk, so empty the filename as a precaution
+		self["clean.comp"] = cub
+
+	# return self["clean.comp"]
+
+	def make_flatnoise(self, overwrite=False):
+		"""
+		Generate a flat noise cube from the primary beam (PB) corrected one, and the PB response (which is <= 1).
+		PB corrected cube has valid fluxes, but rms computation is not straightforward.
+		PB corrected cube = flat noise cube / PB response
+		:param overwrite: If true, overrides any present "image"" cube.
+		:return: None
+		"""
+		self.log("Generate flat noise image cube from the PB corrected one.")
+
+		if self["image.pbcor"] is None:
+			raise ValueError("PB corrected cleaned cube is missing.")
+		if self["pb"] is None:
+			raise ValueError("PB response cube is missing.")
+		if self["image"] is not None and not overwrite:
+			self.log("Warning: image cube already exists and overwriting is disabled.")
+
+		cub = Cube(self["image.pbcor"].filename)
+		cub.im = self["image.pbcor"].im * self["pb"].im
+		cub.filename = None  # This cube is no longer the one on disk, so empty the filename as a precaution
+		self["image"] = cub
+
+	# return self["image"]
+
+	def __cubes_prepare(self) -> bool:
+		"""
+		Perform several prelimiaries before attempting residual scaled flux extraction.
+		:return: True if no problems are detected, False otherwise.
+		"""
+
+		# if necessary, use pb corrected map and pb to generate flat noise map
+		only_pbcor_exists = self["image"] is None and self["image.pbcor"] is not None and self["image.pb"] is not None
+		if only_pbcor_exists:
+			self.make_flatnoise()
+
+		cubes_exists = self["image"] is not None and self["dirty"] is not None and self["residual"] is not None
+		if not cubes_exists:
+			self.log("Error: Need all three cubes: image, dirty, residual!")
+			return False
+
+		# generate clean component cube (this is not a standard CASA output)
+		# actually it is not necessary to have the full cube for residual scaling
+		# if self["clean.comp"] is None:
+		# 	self.make_clean_comp()
+
+		shapes_equal = self["image"].im.shape == self["dirty"].im.shape == self["residual"].im.shape
+		if not shapes_equal:
+			self.log("Error: Cube shapes are not equal!")
+			return False
+
+		# Residual scaling assumes clean beam in all maps
+		# Override the beam volume in dirty and residual maps to the cleaned one
+		bvol = self["image"].beamvol
+		self["dirty"].beamvol = bvol
+		self["residual"].beamvol = bvol
+
+		return True
+
+	def spectrum_corrected(self, ra: float = None, dec: float = None, freq: float = None, radius: float = 1.0,
+						   px: int = None, py: int = None, channel: int = None,
+						   calc_error=True, sn_cut: float = 2.5, apply_pb_corr=True):
+		"""
+		Extract aperture integrated spectrum from the cube using the residual scaling to account for the dirty beam.
+		Correction for the primary beam response is applied if avaliable.
+		Coordinates can be given in degrees (ra, dec) or pixels (px, py).
+		If no coordinates are given, the center of the map is assumed.
+
+		For details on the method see appendix A in Novak et al. (2019):
+		https://ui.adsabs.harvard.edu/abs/2019ApJ...881...63N/abstract
+
+		:param ra: Right ascention in degrees.
+		:param dec: Declination in degrees.
+		:param radius: Circular aperture radius in arcsec.
+		:param px: Right ascention pixel coord (alternative to ra).
+		:param py: Declination pixel coord (alternative to dec).
+		:param channel: Channel index (alternative to freq)
+		:param freq: Frequency in GHz. Extract only in a single channel instead of the full cube.
+		:param calc_error: Set to False to skip error calculations, if the rms computation is slow or not necessary.
+		:param sn_cut: Use emission above this S/N threshold to estimate the clean-to-dirty beam ratio, need calc_error.
+		:param apply_pb_corr: Scale flux and error by the primary beam response (single pix value), needs loaded pb map.
+		:return: flux, err, tab: 1D array for corrected flux and error estimate; tab is a Table with all computations.
+		"""
+
+		# take single pixel value if no aperture radius given
+		if radius <= 0:
+			raise ValueError("No aperture is defined!")
+
+		# check and prepare cubes for residual scaling
+		if not self.__cubes_prepare():
+			raise ValueError("Cubes check failed!")
+
+		if freq is not None:
+			channel = self["image"].freq2pix(freq)
+
+		# run aperture extraction on all cubes
+		# the beam volume should be the same in all of them (checked by __cubes_prepare)
+		params = dict(ra=ra, dec=dec, radius=radius, px=px, py=py, channel=channel, freq=freq)
+		flux_image, err, npix = self["image"].spectrum(calc_error=calc_error, **params)  # compute rms only on this map
+		flux_residual, _, _ = self["residual"].spectrum(calc_error=False, **params)
+		flux_dirty, _, _ = self["dirty"].spectrum(calc_error=False, **params)
+		flux_clean = flux_image - flux_residual
+
+		# alternatively, force creation of the clean components cube
+		# self.make_clean_comp()
+		# flux_clean, _, _ = self["clean.comp"].spectrum(calc_error=False, **params)
+
+		# this can be numerically unstable if there is no clean flux or if dirty == residual
+		# nothing much to do about it, it's a limitation of the method
+		epsilon = flux_clean / (flux_dirty - flux_residual)
+
+		# estimate a single epsilon across the full spectrum
+		# it is not expected to change a lot across channels (if PSF is consistent, and bandwidth is not too large)
+		epsilon_fix = float(np.nanmedian(epsilon))
+		if calc_error:
+			if channel is None:
+				rmses = self["image"].rms
+			else:
+				rmses = np.array([self["image"].rms[channel]])
+			# use only high S/N channels
+			w = (flux_clean / err) > sn_cut
+			if np.sum(w) > 0:
+				epsilon_fix = np.nanmedian(epsilon[w])
+			else:
+				self.log("Warning: Nothing above S/N>" + str(sn_cut) + ", using all channels for epsilon.")
+		else:
+			rmses = np.full_like(flux_image, fill_value=np.nan)
+			self.log("Using all channels for clean-to-dirty beam ratio (epsilon).")
+
+		# corrected flux is estimated from the dirty map and the clean-to-dirty beam ratio (epsilon)
+		flux = epsilon_fix * flux_dirty
+		err = epsilon_fix * err  # TODO: should the error estimate be scaled with epsilon as well?
+
+		# apply PB correction if possible
+		if apply_pb_corr and "pb" in self.loaded_cubes:
+			self.log("Correcting flux and err for PB response.")
+			pb, _, _ = self["pb"].spectrum(ra=ra, dec=dec, px=px, py=py, channel=channel, freq=freq, calc_error=False)
+			flux = flux / pb
+			err = err / pb
+		elif apply_pb_corr and "pb" not in self.loaded_cubes:
+			self.log("Warning: Cannot correct for PB, missing pb map.")
+			pb = np.full(len(flux_image), np.nan)
+		else:
+			self.log("Flux is not PB corrected.")
+			pb = np.full(len(flux_image), np.nan)
+
+		# crude estimate if something went poorly, epsilon is too small or too big
+		if epsilon_fix < 0.01 or epsilon_fix > 100:
+			self.log("Warning: The clean-to-dirty beam ratio (epsilon) is badly determined.")
+		epsilon_fix = np.full(len(flux), epsilon_fix)
+
+		if channel is None:
+			channels = np.arange(len(flux))
+		else:
+			channels = [channel]
+
+		freqs = self.freqs[channels]
+		nbeam = npix / self["image"].beamvol
+
+		tab = Table([channels,  # Channel index
+					 freqs,  # Frequency of the channel in GHz
+					 flux,  # Aperture flux corrected for residual and primary beam response
+					 err,  # Error estimate on the corrected flux
+					 epsilon_fix,  # Best estimate of the clean-to-dirty beam ratio, fixed across all channels
+					 flux_image,  # Aperture flux measured in the final map (assumes clean beam)
+					 flux_dirty,  # Aperture flux measured in the dirty map (assumes clean beam)
+					 flux_residual,  # Aperture flux measured in the residual map (assumes clean beam)
+					 flux_clean,  # Aperture flux measured in the clean components map (= final - residual)
+					 npix,  # Number of pixels inside the aperture
+					 nbeam,  # Number of beams inside the aperture
+					 epsilon,  # Clean-to-dirty beam ratio in the channel
+					 rmses,  # Rms noise of the channel
+					 pb],  # Primary beam response (<=1) at the given coordinate, single pixel value
+					names=["channel", "freq", "flux", "err", "epsilon_fix",
+						   "flux_image", "flux_dirty", "flux_residual", "flux_clean",
+						   "npix", "nbeam", "epsilon", "rms", "pb"])
+
+		return np.array(flux), np.array(err), tab
+
+	def growing_aperture_corrected(self, ra: float = None, dec: float = None, freq: float = None,
+								   maxradius=1.0, binspacing: float = None, bins: list = None,
+								   px: int = None, py: int = None, channel: int = 0,
+								   calc_error=True, apply_pb_corr=True):
+		"""
+		Extract the curve of growth from the map using the residual scaling to account for the dirty beam.
+		Correction for the primary beam response is applied if avaliable.
+		Coordinates can be given in degrees (ra, dec) or pixels (px, py).
+		If no coordinates are given, the center of the map is assumed.
+
+		For details on the method see appendix A in Novak et al. (2019):
+		https://ui.adsabs.harvard.edu/abs/2019ApJ...881...63N/abstract
+
+		:param ra: Right ascention in degrees.
+		:param dec: Declination in degrees.
+		:param freq: Frequency in GHz.
+		:param maxradius: Max radius for aperture integration in arcsec.
+		:param binspacing: Resolution of the growth flux curve in arcsec, default is one pixel size.
+		:param bins: Custom bins for curve growth (1D np array).
+		:param px: Right ascention pixel coord (alternative to ra).
+		:param py: Declination pixel coord (alternative to dec).
+		:param channel: Index of the cube channel to take (alternative to freq). Default is the first channel.
+		:param calc_error: Set to False to skip error calculations, if the rms computation is slow or not necessary.
+		:param apply_pb_corr: Scale flux and error by the primary beam response (single pix value), needs loaded pb map.
+		:return: radius, flux, err, tab:  1D array for radius[arcsec] and corrected flux and error estimate;
+		tab is a Table with all computations.
+		"""
+
+		# check and prepare cubes for residual scaling
+		if not self.__cubes_prepare():
+			raise ValueError("Cubes check failed!")
+
+		# define channel to use
+		if freq is not None:
+			channel = self["image"].freq2pix(freq)
+
+		# run growing aperture extraction on all cubes in a single channel
+		# the beam volume should be the same in all of them (checked by __cubes_prepare)
+		params = dict(ra=ra, dec=dec, maxradius=maxradius,
+					  px=px, py=py, channel=channel, freq=freq,
+					  binspacing=binspacing, bins=bins, profile=False)  # shared parameters
+		radius, flux_image, err, npix = self["image"].growing_aperture(calc_error=calc_error, **params)  # rms here only
+		_, flux_residual, _, _ = self["residual"].growing_aperture(calc_error=False, **params)
+		_, flux_dirty, _, _ = self["dirty"].growing_aperture(calc_error=False, **params)
+		flux_clean = flux_image - flux_residual
+
+		epsilon = flux_clean / (flux_dirty - flux_residual)
+		flux = np.array(epsilon * flux_dirty)
+		err = epsilon * err  # TODO: should the error estimate be scaled with epsilon as well?
+		nbeam = npix / self["image"].beamvol[channel]
+
+		# apply PB correction if possible
+		if apply_pb_corr and "pb" in self.loaded_cubes:
+			self.log("Correcting flux and err for PB response.")
+			# will return a single pb value, because channel is set
+			pb, _, _ = self["pb"].spectrum(ra=ra, dec=dec, px=px, py=py, channel=channel, freq=freq, calc_error=False)
+			pb = np.full(len(flux_image), pb)
+			flux = np.array(flux / pb)
+			err = np.array(err / pb)
+		elif apply_pb_corr and "pb" not in self.loaded_cubes:
+			self.log("Warning: Cannot correct for PB, missing pb map.")
+			pb = np.full(len(flux_image), np.nan)
+		else:
+			self.log("Flux is not PB corrected.")
+			pb = np.full(len(flux_image), np.nan)
+
+		tab = Table([radius,  # Aperture radius in arcsec.
+					 flux,  # Aperture flux corrected for residual
+					 err,  # Error estimate on the corrected flux
+					 flux_image,  # Aperture flux measured in the final map (assumes clean beam)
+					 flux_dirty,  # Aperture flux measured in the dirty map (assumes clean beam)
+					 flux_residual,  # Aperture flux measured in the residual map (assumes clean beam)
+					 flux_clean,  # Aperture flux measured in the clean components map (= final - residual)
+					 epsilon,  # Clean-to-dirty beam ratio for a given aperture size
+					 npix,  # Number of pixels inside the aperture
+					 nbeam,  # Number of beams inside the aperture: nbeam = npix / beamvol
+					 pb],  # Primary beam response (<=1) applied to flux and err columns, single value at all radii
+					names=["radius", "flux", "err",
+						   "flux_image", "flux_dirty", "flux_residual", "flux_clean",
+						   "epsilon", "npix", "nbeam", "pb"])
+
+		return radius, flux, err, tab

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,0 +1,457 @@
+import os
+from copy import deepcopy
+import numpy as np
+import scipy.constants as const
+from scipy.optimize import curve_fit
+from scipy.interpolate import interp2d
+import astropy.units as u
+from astropy.cosmology import FlatLambdaCDM
+from astropy.io import fits
+from astropy import wcs
+from astropy.coordinates import SkyCoord
+
+
+def sigfig(x, digits=2):
+	"""
+	Round a number to a number of significant digits.
+	:param x: Input number.
+	:param digits: Number of significant digits.
+	:return:
+	"""
+	if x == 0:
+		return 0
+	else:
+		return round(x, digits - int(np.floor(np.log10(abs(x)))) - 1)
+
+
+def weighted_avg(values, weights):
+	"""
+	Compute weighted average of a masked array. Used in computing mean amplitude vs uv from flagged data.
+	:param values: Input masked array.
+	:param weights: Input weights.
+	:return: average, standard_error, standard_deviation
+	"""
+	average = np.ma.average(values, weights=weights)
+	variance = np.ma.average((values - average) ** 2, weights=weights)
+	standard_deviation = np.ma.sqrt(variance)
+	standard_error = standard_deviation / np.ma.sqrt(sum(weights))  # need -1?
+	return average, standard_error, standard_deviation
+
+
+def gauss(x, a, mu, sigma):
+	"""
+	Gaussian profile. Not normalized.
+	:param x: Values of x where to compute the profile.
+	:param a: Gaussian amplitude (peak height).
+	:param mu: Gaussian center (peak position).
+	:param sigma: Gaussian sigma (width).
+	:return: Value at x.
+	"""
+	return a * np.exp(-(x - mu) ** 2 / (2 * sigma ** 2))
+
+
+def gausscont(x, b, a, mu, sigma):
+	"""
+	Gaussian profile (not normalized) on top of a constant continuum.
+	:param x: Values of x where to compute the profile.
+	:param b: Constant offset (in y-axis direction).
+	:param a: Gaussian amplitude (peak height).
+	:param mu: Gaussian center (peak position).
+	:param sigma: Gaussian sigma (width).
+	:return: Value at x.
+	"""
+	return b + gauss(x, a, mu, sigma)
+
+
+def fwhm2sig(fwhm):
+	"""
+	Convert Gaussian FWHM to sigma.
+	"""
+	return np.abs(fwhm) / (2 * np.sqrt(2 * np.log(2)))
+
+
+def sig2fwhm(sigma):
+	"""
+	Convert Gaussian sigma to FWHM.
+	"""
+	return np.abs(sigma) * (2 * np.sqrt(2 * np.log(2)))
+
+
+def kms2mhz(width_kms, freq_ghz):
+	"""
+	Convert channel width in km/s into MHz at the specified reference frequency.
+	:param width_kms:
+	:param freq_ghz:
+	:return:
+	"""
+	return width_kms / (const.c / 1000) * freq_ghz * 1000  # widthmhz
+
+
+def mhz2kms(width_mhz, freq_ghz):
+	"""
+	Convert channel width in MHz into km/s at the specified reference frequency.
+	:param width_mhz:
+	:param freq_ghz:
+	:return:
+	"""
+	return width_mhz / (freq_ghz * 1000) * (const.c / 1000)  # widthkms
+
+
+def kms2ghz(width_kms, freq_ghz):
+	"""
+	Convert channel width in km/s into GHz at the specified reference frequency.
+	:param width_kms:
+	:param freq_ghz:
+	:return:
+	"""
+	return width_kms / (const.c / 1000) * freq_ghz  # widthghz
+
+
+def ghz2kms(width_ghz, freq_ghz):
+	"""
+	Convert channel width in GHz into km/s at the specified reference frequency.
+	:param width_ghz:
+	:param freq_ghz:
+	:return:
+	"""
+	return width_ghz / freq_ghz * (const.c / 1000)  # widthkms
+
+
+def calcrms(arr, fitgauss=False, around_zero=True, clip_sigma=3, maxiter=20):
+	"""
+	Calculate rms by iteratively disregarding outlier pixels (beyond clip_sigma x rms values).
+	:param arr: Input array.
+	:param fitgauss: If True, Gaussian will be fitted onto the distribution of negative pixels.
+	:param around_zero: Assume no systematic offsets, i.e., noise oscillates around zero.
+	:param clip_sigma: Clip values beyond these many sigmas (in both positive and negative directions).
+	:param maxiter: Maximum number of iterations to perform.
+	:return: rms or, if fitgauss is Truem rms and Gaussian sigma
+	"""
+	a = arr[np.isfinite(arr)].flatten()
+	rms = 0
+
+	# TODO: likely a similar function already exists in some statistical library (look for Chauvenet)
+
+	# iteratively calc rms and remove all values outside 3sigma
+	mu = 0
+	n = 0
+	for i in range(maxiter):
+		# mean of 0 is expected for noise
+		if not around_zero:
+			mu = np.nanmean(a)
+
+		if len(a) > 0:
+			rms = np.sqrt(np.mean(a ** 2))
+		else:
+			# rms = 0
+			break
+
+		w = (a > mu - clip_sigma * rms) & (a < mu + clip_sigma * rms)
+		if n == np.sum(w):
+			break
+		a = a[w]
+		n = np.sum(w)
+
+	# alternative noise estimation: fit a Gaussian to the negative part of the pixel distribution
+	# uses previous rms result as the intiial fit guess (p0)
+	if fitgauss:
+		bins = np.linspace(-10 * rms, 0, 100)
+		bincen = 0.5 * (bins[1:] + bins[:-1])
+		h = np.histogram(arr, bins=bins)[0]
+
+		# mirror negative part for fitting
+		xxx = np.append(bincen, -1 * bincen[::-1])
+		yyy = np.append(h, h[::-1])
+
+		popt, pcov = curve_fit(lambda x, a, sigma: gauss(x, a, 0, sigma), xxx, yyy, p0=(np.max(yyy), rms))
+		a, sigma = popt
+		sigma = np.abs(sigma)
+
+		return rms, sigma
+	else:
+		return rms
+
+
+def beam_volume_sr(bmaj, bmin=None):
+	"""
+	Compute Gaussian beam volume.
+	:param bmaj: Major axis FWHM in arcsec.
+	:param bmin: Minor axis FWHM in arcsec. If not provided, will assume circular beam bmin=bmaj.
+	:return: Beam volume in steradians.
+	"""
+
+	# bmaj and bmin are major and minor FWHMs of a Gaussian (synthesised) beam, in arcsec
+	if bmin is None:
+		bmin = bmaj
+
+	omega = np.pi / 4 / np.log(2) * (bmaj / 3600 / 180 * np.pi) * (bmin / 3600 / 180 * np.pi)  # convert to radians
+	return omega
+
+
+def surf_temp(freq, rms, theta):
+	"""
+	Copmute surface brightness temperature sensitivity in Kelvins. Used to compare radio map sensitivities.
+	:param freq: Observed frequency in GHz.
+	:param rms: Noise in the map in Jy/beam.
+	:param theta: Beam FWHM in arcsec. Assumes circular beam.
+	:return: Temperature in Kelvins.
+	"""
+
+	temp = rms * 1e-26 / beam_volume_sr(theta) * const.c ** 2 / (2 * const.k * (freq * 1e9) ** 2)
+	return temp
+
+
+def blackbody(nu, temp):
+	"""
+	Planck's law for black body emission, per unit frequency.
+	:param nu: Rest frame frequency in Hz.
+	:param temp: Temperature in K.
+	:return: Emission in units of W / (m^2 Hz)
+	"""
+	return 2 * const.h * nu ** 3 / const.c ** 2 / (np.exp(const.h * nu / (const.k * temp)) - 1)
+
+
+def dust_lum(nu_rest, Mdust, Tdust, beta):
+	"""
+	Compute intrinsic dust luminosity at specific rest frame frequency assuming modified black body emission.
+	:param nu_rest: Rest frame frequency in Hz.
+	:param Mdust: Total dust mass in kg.
+	:param Tdust:  Dust temperature in K.
+	:param beta: Emissivity coefficient, dimensionless.
+	:return: Luminosity (at rest frequency nu) in W/Hz
+	"""
+
+	# dust opacity from Dunne+2003
+	kappa_ref = 2.64  # m**2/kg
+	kappa_nu_ref = const.c / 125e-6  # Hz
+
+	# Dunne+2000 ?
+	# kappa_ref=0.77*u.cm**2/u.g
+	# kappa_ref=kappa_ref.to(u.m**2/u.kg).value
+	# kappa_nu_ref=c/850e-6
+
+	lum_nu = 4 * const.pi * kappa_ref * (nu_rest / kappa_nu_ref) ** beta * Mdust * blackbody(nu_rest, Tdust)
+	return lum_nu
+
+
+def dust_sobs(nu_obs, z, mass_dust, temp_dust, beta, cmb_contrast=True, cmb_heating=True):
+	"""
+	Compute observed flux density of the dust continuum, assuming a modified black body.
+	:param nu_obs: Observed frame frequency in Hz.
+	:param z: Redshift of the source.
+	:param mass_dust: Total dust mass in kg.
+	:param temp_dust: Intrinsic dust temperature in K (the source would have at z=0).
+	:param beta: Emissivity coefficient, dimensionless.
+	:param cmb_contrast: Correct for cosmic microwave background contrast.
+	:param cmb_heating: Correct for cosmic microwave background heating (important at high z where Tcmb ~ Tdust).
+	:return: Observed flux density in W/Hz/m^2.
+	"""
+
+	cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+	dl = cosmo.luminosity_distance(z).to(u.m).value  # m
+	nu_rest = nu_obs * (1 + z)
+	temp_cmb0 = 2.73  # cmb temperature at z=0
+	temp_cmb = (1 + z) * temp_cmb0
+
+	# cmb heating (high redshift) and contrast corrections from da Cunha+2013
+	if cmb_heating:
+		temp_dustz = (temp_dust ** (4 + beta) + temp_cmb0 ** (4 + beta) * ((1 + z) ** (4 + beta) - 1)) ** (1 / (4 + beta))
+	else:
+		temp_dustz = temp_dust
+
+	if cmb_contrast:
+		f_cmb = 1. - blackbody(nu_rest, temp_cmb) / blackbody(nu_rest, temp_dustz)
+	else:
+		f_cmb = 1
+
+	flux_obs = f_cmb * (1 + z) / (4 * np.pi * dl ** 2) * dust_lum(nu_rest, mass_dust, temp_dustz, beta)
+
+	return flux_obs
+
+
+def stack2d(ras, decs, im, imhead, imrms=None, pathout=None, overwrite=False, naxis=100, interpol=True):
+	"""
+	Perform median and mean (optionally rms weighted) stacking of multiple sources in a single radio map.
+	This function requires that the first index is the x coordinate, and the second one y.
+	If the map was opened with the fits package, it likely has to be transposed first with im.T.
+	Opening the map as interferopy.Cube object does this transposition automatically.
+
+	:param ras: List of right ascentions.
+	:param decs: List of declinations.
+	:param im: 2D radio map indexed as im[ra,dec].
+	:param imhead: Image header.
+	:param imrms: 2D rms noise map; if provided the mean stack will be noise weigthed.
+	:param pathout: Filename for the output stacks, if None, no output is written to disk.
+	:param overwrite: Overwrites files when saving (pathout).
+	:param naxis: The size of the cutout square in pixels.
+	:param interpol: Perform subpixel inteprolation (bicubic spline)
+	:return: stack_mean, stack_median, stack_head, cube - 2D map, 2D map, text header, 3D cube of cutouts
+	"""
+
+	# how many objects
+	n = len(np.atleast_1d(ras))
+
+	# calculate half of the cutout size
+	halfxis = naxis / 2
+	# one pixel too much in even sized, only odd naxis can have a "central" pixel
+	even_shift = -1 if naxis % 2 == 0 else 0
+
+	# get coord system
+	wc = wcs.WCS(imhead, naxis=2)
+	# pixel coords
+	pxs, pys = wc.all_world2pix(ras, decs, 0)
+
+	# allocate space for the stack cube
+	cube = np.full((naxis, naxis, n), np.nan)
+	cuberms = np.full((naxis, naxis, n), 1.0)
+
+	# fill the cube with (interpolated) cutouts
+	for i in range(n):
+		# source position in pixels (float)
+		px = np.atleast_1d(pxs)[i]
+		py = np.atleast_1d(pys)[i]
+
+		if interpol:
+			# offset between the source and pixel centres
+			xoff = px - int(px)
+			yoff = py - int(py)
+			# truncate source center for array positioning for interpolation
+			px = int(px)
+			py = int(py)
+		else:
+			xoff = 0
+			yoff = 0
+			# round the pixel to closest integer when not interpolating
+			px = int(round(px))
+			py = int(round(py))
+
+		# calculate different offsets for cropping (edge effects)
+		left = int(px - halfxis)
+		right = int(px + halfxis + even_shift)
+		bottom = int(py - halfxis)
+		top = int(py + halfxis + even_shift)
+		crop_left = int(-min([left, 0]))
+		crop_right = int(min([im.shape[0] - 1 - right, 0]))
+		crop_bottom = int(-min([bottom, 0]))
+		crop_top = int(min([im.shape[1] - 1 - top, 0]))
+
+		# initialize cutout
+		subim = np.full((naxis, naxis), np.nan)
+		subimrms = np.full((naxis, naxis), 1.0)
+
+		# check if the cutout is at least partially inside the map
+		not_in_map = abs(crop_left) >= naxis or abs(crop_right) >= naxis \
+					 or abs(crop_bottom) >= naxis or abs(crop_top) >= naxis
+
+		if not not_in_map:
+			# get cutout from the map, nans are left where no data is available
+			# interpolate so that stacking coord is in the middle pixel
+			# cut if cutout is at least partially inside the map
+
+			subim[0 + crop_left:naxis - 1 + crop_right + 1, 0 + crop_bottom:naxis - 1 + crop_top + 1] = \
+				im[left + crop_left:right + crop_right + 1, bottom + crop_bottom:top + crop_top + 1]
+			if imrms is not None:
+				subimrms[0 + crop_left:naxis - 1 + crop_right + 1, 0 + crop_bottom:naxis - 1 + crop_top + 1] = \
+					imrms[left + crop_left:right + crop_right + 1, bottom + crop_bottom:top + crop_top + 1]
+
+			if interpol:
+				# nans are not handled in interpolation, replace them temporarily with 0
+				w = np.isnan(subim)
+				subim[w] = 0
+				subimrms[w] = 1.0
+
+				# bicubic spline
+				f = interp2d(range(naxis), range(naxis), subim, kind='cubic')
+				subim = f(np.array(range(naxis)) + yoff, np.array(range(naxis)) + xoff)
+				subim[w] = np.nan
+
+				if imrms is not None:
+					f2 = interp2d(range(naxis), range(naxis), subimrms, kind='cubic')
+					subimrms = f2(np.array(range(naxis)) + yoff, np.array(range(naxis)) + xoff)
+					subimrms[w] = np.nan
+
+		# other possible interpolation methods:
+
+		# griddata
+		# x = np.linspace(0,naxis-1,naxis)
+		# xcoo, ycoo = np.meshgrid(x,x)
+		# xcof, ycof = np.meshgrid(x+yoff,x+xoff)
+		# subim=griddata( (xcoo.flatten(), ycoo.flatten()), subim.flatten(), (xcof, ycof), method='cubic')
+		# subimrms=griddata( (xcoo.flatten(), ycoo.flatten()), subimrms.flatten(), (xcof, ycof), method='cubic')
+
+		# Rectangular B spline
+		# narr=range(naxis)
+		# sp = interpolate.RectBivariateSpline(narr, narr, subim, kx=4, ky=4, s=0)
+		# subim=sp(narr+xoff, narr+yoff)
+		# sp = interpolate.RectBivariateSpline(narr, narr, subimrms, kx=4, ky=4, s=0)
+		# subimrms=sp(narr+xoff, narr+yoff)
+
+		# add the sourcecutout to the cube
+		cube[:, :, i] = subim
+		cuberms[:, :, i] = subimrms
+
+	# colapse the cube to mean and median stacks while handling NaNs properly
+	cube_masked = np.ma.MaskedArray(cube, mask=~(np.isfinite(cube)))
+	stack_mean = np.ma.average(cube_masked, weights=cuberms ** (-2), axis=2).filled(np.nan)
+	stack_median = np.ma.median(cube_masked, axis=2).filled(np.nan)
+
+	# edit the header to proper axis sizes
+	stack_head = deepcopy(imhead)
+	stack_head['NAXIS1'] = naxis
+	stack_head['NAXIS2'] = naxis
+	stack_head['CRPIX1'] = naxis / 2
+	stack_head['CRPIX2'] = naxis / 2
+
+	# save files
+	if pathout is not None:
+		# remove the extension to append a suffix for different files
+		basepath = os.path.splitext(pathout)[0]
+		# transpose back for proper writing (numpy index ordering rule)
+		fits.writeto(basepath + '_median.fits', stack_median.T, stack_head, overwrite=overwrite)
+		fits.writeto(basepath + '_mean.fits', stack_mean.T, stack_head, overwrite=overwrite)
+		fits.writeto(basepath + '_cube.fits', cube.T, stack_head, overwrite=overwrite)
+	# fits.writeto(basepath+'_cuberms.fits',cuberms.T, stack_head, clobber=True)
+
+	return stack_mean, stack_median, stack_head, cube
+
+
+def sex2deg(ra_hms, dec_dms, frame='icrs'):
+	"""
+	Convert sexagesimal coords (hours:minutes:seconds, degrees:minutes:seconds) to degrees.
+	:param ra_hms: Right ascentions. String or list of strings.
+	:param dec_dms: Declinations. String or list of strings.
+	:param frame: Equinox frame. ALMA default is ICRS.
+	:return: ra_deg, dec_deg - 1D numpy arrays with coords in degrees
+	"""
+
+	# wrap single value in a list for iteration
+	single_val = False
+	if isinstance(ra_hms, str) and isinstance(dec_dms, str):
+		ra_hms = [ra_hms]
+		dec_dms = [dec_dms]
+		single_val = True
+
+	n = len(ra_hms)
+	ra_deg = np.zeros(n)
+	dec_deg = np.zeros(n)
+
+	for i in range(n):
+		coo = SkyCoord(str(ra_hms[i]) + " " + str(dec_dms[i]), frame=frame, unit=(u.hourangle, u.deg))
+		ra_deg[i] = coo.ra.deg
+		dec_deg[i] = coo.dec.deg
+
+	if single_val:
+		return ra_deg[0], dec_deg[0]
+	else:
+		return ra_deg, dec_deg
+
+
+def arcsec2kpc(z: float = 0):
+	"""
+	Return the number of kiloparsecs contained in one arcsecond at given redshift.
+	Use concordance cosmology.
+	:param z: Redshift of the source
+	:return:
+	"""
+	cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+	return 1. / cosmo.arcsec_per_kpc_proper(z).value


### PR DESCRIPTION
That does the trick. Interferopy can now be installed by typing 

>>> python setup.py install

(assuming you have distutil installed, which you should by default I think)

Lots of  additions/deletions but this is only because I moved files around. Only real changes are in "setup.py" and "README.md"