### PR TITLE
findclumps: homogenize filenames (.out -> .cat) and underscores

### DIFF
--- a/interferopy/cube.py
+++ b/interferopy/cube.py
@@ -728,7 +728,8 @@ class Cube:
         :min_SNR: min SNR for final catalogues
         :delta_offset_arcsec: maximum offset to match detections in the cube [arcsec]
         :delta_freq: maximum frequency offset to match detections in the cube [GHz]
-        :run_negative: also run findclumps on the negative cube
+        :run_positive: run findclumps on the positive cube
+        :run_negative: run findclumps on the negative cube
         '''
 
         for i in kernels:

--- a/interferopy/cube.py
+++ b/interferopy/cube.py
@@ -746,14 +746,14 @@ class Cube:
             tools.run_line_stats_sex(sextractor_catalogue_name=output_file + '_clumpsP',
                                      binning_array=kernels, SNR_min=min_SNR)
 
-            tools.crop_doubles(cat_name=output_file + "_clumpsP_minSNR_" + str(min_SNR) + ".out",
+            tools.crop_doubles(cat_name=output_file + "_clumpsP_minSNR_" + str(min_SNR) + ".cat",
                                delta_offset_arcsec=delta_offset_arcsec, delta_freq=delta_freq)
 
         if run_negative:
             tools.run_line_stats_sex(sextractor_catalogue_name=output_file + '_clumpsN',
                                      binning_array=kernels, SNR_min=min_SNR)
 
-            tools.crop_doubles(cat_name=output_file + "_clumpsN_minSNR_" + str(min_SNR) + ".out",
+            tools.crop_doubles(cat_name=output_file + "_clumpsN_minSNR_" + str(min_SNR) + ".cat",
                                delta_offset_arcsec=delta_offset_arcsec, delta_freq=delta_freq)
 
 

--- a/interferopy/cube.py
+++ b/interferopy/cube.py
@@ -715,8 +715,8 @@ class Cube:
     def findclumps_full(self, output_file, kernels=np.arange(3, 20, 2), rms_region=1. / 4.,
                         sextractor_param_file='default.sex', clean_tmp=True, min_SNR=0,
                         delta_offset_arcsec=2, delta_freq=0.1,
-                        run_positive=True,
-                        run_negative=True):
+                        run_positive=True, run_negative=True,
+                        verbose=False):
         '''
         Run the findclump search for different kernels sizes, on the positive (and negative) cube(s).
         Crops doubles and trim candidates above a mininum SNR. See findclumps_1kernel().
@@ -730,6 +730,7 @@ class Cube:
         :delta_freq: maximum frequency offset to match detections in the cube [GHz]
         :run_positive: run findclumps on the positive cube
         :run_negative: run findclumps on the negative cube
+        :verbose: increase verbosity. note: to mute sextractor, modify ``VERBOSE_TYPE`` in ``default.sex``
         '''
 
         for i in kernels:
@@ -748,14 +749,18 @@ class Cube:
                                      binning_array=kernels, SNR_min=min_SNR)
 
             tools.crop_doubles(cat_name=output_file + "_clumpsP_minSNR_" + str(min_SNR) + ".cat",
-                               delta_offset_arcsec=delta_offset_arcsec, delta_freq=delta_freq)
+                               delta_offset_arcsec=delta_offset_arcsec,
+                               delta_freq=delta_freq,
+                               verbose=verbose)
 
         if run_negative:
             tools.run_line_stats_sex(sextractor_catalogue_name=output_file + '_clumpsN',
                                      binning_array=kernels, SNR_min=min_SNR)
 
             tools.crop_doubles(cat_name=output_file + "_clumpsN_minSNR_" + str(min_SNR) + ".cat",
-                               delta_offset_arcsec=delta_offset_arcsec, delta_freq=delta_freq)
+                               delta_offset_arcsec=delta_offset_arcsec,
+                               delta_freq=delta_freq,
+                               verbose=verbose)
 
 
 class MultiCube:

--- a/interferopy/tools.py
+++ b/interferopy/tools.py
@@ -509,17 +509,17 @@ def run_line_stats_sex(sextractor_catalogue_name,
     :param sextractor_catalogue_name: Generic catalogue name for the field, excluding kernel half-width
     :param binning_array: array of kernel half-width to process for the given field
     :param SNR_min: Threshold SN to select clump detections
-    :return: Saves region files (input name +".reg") and catalogues (input name +".out") for later study
+    :return: Saves region files (input name +".reg") and catalogues (input name +".cat") for later study
     '''
 
     # open region files in overwrite mode
-    with open(sextractor_catalogue_name+'minSNR_'+str(SNR_min)+'.reg', 'w+') as clumps_reg:
+    with open(sextractor_catalogue_name+'_minSNR_'+str(SNR_min)+'.reg', 'w+') as clumps_reg:
         clumps_reg.write('# Region file format: DS9 version 4.1 \n '
                          'global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 '
                          'dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1 \n')
         clumps_reg.write('fk5 \n')
 
-        clumps_name_out = sextractor_catalogue_name+'_minSNR_'+str(SNR_min)+'.out'
+        clumps_name_out = sextractor_catalogue_name+'_minSNR_'+str(SNR_min)+'.cat'
 
         for binning in binning_array:
             catalogue = np.loadtxt(sextractor_catalogue_name + '_kw' + str(int(binning)) + '.cat')

--- a/interferopy/tools.py
+++ b/interferopy/tools.py
@@ -1,4 +1,5 @@
 import os
+from tqdm import tqdm
 from copy import deepcopy
 import numpy as np
 import scipy.constants as const
@@ -544,7 +545,7 @@ def run_line_stats_sex(sextractor_catalogue_name,
                                header="RA DEC FREQ_GHZ X Y SNR FLUX_MAX BINNING")
 
 
-def crop_doubles(cat_name, delta_offset_arcsec=2, delta_freq=0.1):
+def crop_doubles(cat_name, delta_offset_arcsec=2, delta_freq=0.1, verbose=False):
     '''
     Takes a catalogue of clumps and group sources likely from the same target. Tolerance in sky posoition and frequency
     to be given. If the data is not continuum-subtracted, continuum sources will result in multiple groups of clumps
@@ -552,6 +553,7 @@ def crop_doubles(cat_name, delta_offset_arcsec=2, delta_freq=0.1):
     :param cat_name:
     :param delta_offset_arcsec:
     :param delta_freq:
+    :param verbose: show a progress bar, useful for time-consuming crops
     :return: Writes a copy of the input catalogue, with the added group number for each clump ("_groups.cat"),
     a reduced catalogue with the highest SN detection for each group ("_cropped.cat"), a region files to plot the
     positions of the latter.
@@ -568,7 +570,12 @@ def crop_doubles(cat_name, delta_offset_arcsec=2, delta_freq=0.1):
     group = -np.ones(len(catalogue_data))
     ncnt = 0
 
-    for i in range(len(catalogue_data)):
+    if verbose:
+        print("Cropping doubles:")
+        iterable = tqdm(range(len(catalogue_data)))
+    else:
+        iterable = range(len(catalogue_data))
+    for i in iterable:
 
         if group[i] < 0:
             group[i] = ncnt
@@ -594,7 +601,12 @@ def crop_doubles(cat_name, delta_offset_arcsec=2, delta_freq=0.1):
                header="RA DEC FREQ_GHZ X Y SNR FLUX_MAX BINNING GROUP")
 
     catalogue_cropped_best = np.zeros((ncnt - 2, len(catalogue_final[0])))
-    for i in range(ncnt - 2):
+    if verbose:
+        print("Filtering highest S/N sources:")
+        iterable = tqdm(range(ncnt -2))
+    else:
+        iterable = range(ncnt - 2)
+    for i in iterable:
         ind = np.where([catalogue_final[:, -1] == i])[1]
         if len(ind) > 1:
             argmax_SN = np.argmax(catalogue_final[ind, 5])


### PR DESCRIPTION
@rameyer

It makes sense to me to homogenize the filenames a bit, unless there is a particular reason to name one of them `.out`?

FYI, I already pushed a couple commits that fix findclumps (which was actually broken due to wrong indents).
