### PR TITLE
define public attributes and enable interferopy direct usage

### DIFF
--- a/interferopy/__init__.py
+++ b/interferopy/__init__.py
@@ -4,3 +4,7 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     pass  # package is not installed
+
+__all__ = ['cube', 'tools', 'casatools', 'casatools_vla_pipe']
+
+from . import cube, tools, casatools, casatools_vla_pipe

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,3 @@ Setup script
 
 from setuptools import setup
 setup(use_scm_version=True)
-


### PR DESCRIPTION
define the public attributes and allow direct usage like

```
import interferopy

interferopy.cube.do_something_directly()
```